### PR TITLE
Fix CI dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-vendored

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,17 +8,17 @@ on:
 jobs:
   pre-commit:
     name: Lint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - uses: pre-commit/action@v3.0.0
+      - uses: pre-commit/action@v3.0.1
 
   test:
     name: Python
@@ -26,19 +26,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [ 3.7, 3.9, "3.10" ]
+        python: [ 3.9, "3.10", "3.11" ]
         os:  [ macos-latest, ubuntu-latest] # disable windows for now, windows-latest ]
     defaults:
       run:
         shell: bash
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python and cache deps
         uses: actions/setup-python@v4
@@ -60,17 +60,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.10.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Python and cache deps
         uses: actions/setup-python@v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: 'pip'
           cache-dependency-path: requirements/CI.txt
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: debug-statements
@@ -12,27 +12,27 @@ repos:
     hooks:
     -   id: copyright-year
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.1.0
+    rev: v3.12.0
     hooks:
       - id: reorder-python-imports
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v3.15.2
     hooks:
       - id: pyupgrade
         args: [--py3-plus, --py37-plus]
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 24.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
     hooks:
       - id: flake8
-        additional_dependencies: ["flake8-bugbear==22.6.22", "flake8-builtins==1.5.3"]
+        additional_dependencies: ["flake8-bugbear==24.2.6", "flake8-builtins==2.2.0"]
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.16.0
     hooks:
       - id: blacken-docs
         args: [--skip-errors]
-        additional_dependencies: [black==22.3.0]
+        additional_dependencies: [black==24.3.0]
         language_version: python3

--- a/requirements/CI.txt
+++ b/requirements/CI.txt
@@ -1,10 +1,10 @@
 coverage==6.4.1
 coveralls==3.3.1
-numba==0.55.2
+numba==0.59.1
 pytest==7.1.2
 pytest-xdist==2.5.0
-tskit==0.5.0
-msprime==1.2.0
-sgkit==0.5.0
+tskit==0.5.6
+msprime==1.3.1
+sgkit==0.7.0
 dendropy==4.5.2
 importlib-metadata==4.13.0


### PR DESCRIPTION
## Changes Summary

### `.gitattributes`
- Added `*.ipynb linguist-vendored`

### `.github/workflows/tests.yml`
#### Modifications
- Changed `runs-on` for the `Lint` job from `ubuntu-18.04` to `ubuntu-latest`.
- Updated `cancel-workflow-action` from `0.6.0` to `0.12.1` in `Lint` job.
- Updated `actions/checkout` from `v2` to `v4`.
- Updated `pre-commit/action` from `v3.0.0` to `v3.0.1` in `Lint` job.
- Updated Python versions in the `test` job to include `3.11` and remove `3.7`.
- Updated `cancel-workflow-action` from `0.10.0` to `0.12.1` in `test` job.
- In `deploy` job, updated `cancel-workflow-action` from `0.10.0` to `0.12.1`.
- Updated Python version from `3.9` to `3.10` in `deploy` job.

### `.pre-commit-config.yaml`
#### Upgrades
- Upgraded `pre-commit-hooks` from `v4.3.0` to `v4.5.0`.
- Upgraded `reorder_python_imports` from `v3.1.0` to `v3.12.0`.
- Upgraded `pyupgrade` from `v2.34.0` to `v3.15.2`, with arguments updated.
- Upgraded `black` from `22.6.0` to `24.3.0`.
- Changed `flake8` repository from GitLab to GitHub, upgrading from `3.9.2` to `6.1.0` with updated additional dependencies.
- Upgraded `blacken-docs` from `v1.12.1` to `1.16.0`, updating additional dependencies.

### `requirements/CI.txt`
#### Package Updates
- `numba` upgraded from `0.55.2` to `0.59.1`.
- `tskit` upgraded from `0.5.0` to `0.5.6`.
- `msprime` upgraded from `1.2.0` to `1.3.1`.
- `sgkit` upgraded from `0.5.0` to `0.7.0`.
